### PR TITLE
NXP-30530: Fix release jobs losing parameters on Jenkins restart

### DIFF
--- a/charts/jenkins/jobs/nuxeo/11.x/release-nuxeo-jsf-ui.groovy
+++ b/charts/jenkins/jobs/nuxeo/11.x/release-nuxeo-jsf-ui.groovy
@@ -31,4 +31,12 @@ pipelineJob('nuxeo/11.x/release-nuxeo-jsf-ui') {
       scriptPath('ci/Jenkinsfiles/release.groovy')
     }
   }
+  parameters {
+    string {
+      name('NUXEO_RELEASE_VERSION')
+      defaultValue('')
+      description('Nuxeo release version.')
+      trim(true)
+    }
+  }
 }

--- a/charts/jenkins/jobs/nuxeo/11.x/release-nuxeo.groovy
+++ b/charts/jenkins/jobs/nuxeo/11.x/release-nuxeo.groovy
@@ -31,4 +31,12 @@ pipelineJob('nuxeo/11.x/release-nuxeo') {
       scriptPath('ci/Jenkinsfiles/release.groovy')
     }
   }
+  parameters {
+    string {
+      name('BUILD_VERSION')
+      defaultValue('')
+      description('Version of the Nuxeo Server build to promote')
+      trim(true)
+    }
+  }
 }

--- a/charts/jenkins/jobs/nuxeo/lts/release-nuxeo-2021.groovy
+++ b/charts/jenkins/jobs/nuxeo/lts/release-nuxeo-2021.groovy
@@ -31,4 +31,12 @@ pipelineJob('nuxeo/lts/release-nuxeo-2021') {
       scriptPath('ci/Jenkinsfiles/release.groovy')
     }
   }
+  parameters {
+    string {
+      name('BUILD_VERSION')
+      defaultValue('')
+      description('Version of the Nuxeo Server build to promote')
+      trim(true)
+    }
+  }
 }

--- a/charts/jenkins/jobs/nuxeo/lts/release-nuxeo-hf-2021.groovy
+++ b/charts/jenkins/jobs/nuxeo/lts/release-nuxeo-hf-2021.groovy
@@ -31,4 +31,12 @@ pipelineJob('nuxeo/lts/release-nuxeo-hf-2021') {
       scriptPath('Jenkinsfiles/release-hf.groovy')
     }
   }
+  parameters {
+    string {
+      name('NUXEO_CURRENT_VERSION')
+      defaultValue('')
+      description('Nuxeo hotfix package version.')
+      trim(true)
+    }
+  }
 }

--- a/charts/jenkins/jobs/nuxeo/lts/release-nuxeo-jsf-ui-2021.groovy
+++ b/charts/jenkins/jobs/nuxeo/lts/release-nuxeo-jsf-ui-2021.groovy
@@ -31,4 +31,12 @@ pipelineJob('nuxeo/lts/release-nuxeo-jsf-ui-2021') {
       scriptPath('ci/Jenkinsfiles/release.groovy')
     }
   }
+  parameters {
+    string {
+      name('NUXEO_RELEASE_VERSION')
+      defaultValue('')
+      description('Nuxeo release version.')
+      trim(true)
+    }
+  }
 }


### PR DESCRIPTION
By setting pipeline parameters in job descriptions.