### PR TITLE
NXP-30452: Increase maven container memory resource

### DIFF
--- a/charts/jenkins/pod-templates/nuxeo-platform-11.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-platform-11.yaml.gotmpl
@@ -14,9 +14,9 @@
     name: "maven"
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "4"
-    resourceLimitMemory: "4Gi"
+    resourceLimitMemory: "8Gi"
     resourceRequestCpu: "4"
-    resourceRequestMemory: "4Gi"
+    resourceRequestMemory: "8Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   - args: ""

--- a/charts/jenkins/pod-templates/nuxeo-platform-15.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-platform-15.yaml.gotmpl
@@ -14,9 +14,9 @@
     name: "maven"
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "4"
-    resourceLimitMemory: "4Gi"
+    resourceLimitMemory: "8Gi"
     resourceRequestCpu: "4"
-    resourceRequestMemory: "4Gi"
+    resourceRequestMemory: "8Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   - args: ""

--- a/charts/jenkins/pod-templates/nuxeo-platform-lts-2021.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-platform-lts-2021.yaml.gotmpl
@@ -14,9 +14,9 @@
     name: "maven"
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "4"
-    resourceLimitMemory: "4Gi"
+    resourceLimitMemory: "8Gi"
     resourceRequestCpu: "4"
-    resourceRequestMemory: "4Gi"
+    resourceRequestMemory: "8Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   - args: ""


### PR DESCRIPTION
The Maven build has Xms=2g and Xmx=3g. The javadoc command gets Xms=1g and Xmx=1g, as they are at most 4 threads compiling the javadoc, we need to times these numbers by 4.

This results in a minimum request for 7G.