### PR TITLE
NXBT-3534: Remove unrecognized VM options since JDK 11

### DIFF
--- a/charts/jenkins/values.yaml.gotmpl
+++ b/charts/jenkins/values.yaml.gotmpl
@@ -16,8 +16,6 @@ controller:
     value: /run/secrets/jenkins-casc
   # Among others, enable permissions for the extended-read-permission plugin.
   javaOpts: >
-    -XX:+UnlockExperimentalVMOptions
-    -XX:+UseCGroupMemoryLimitForHeap
     -XX:MaxRAMFraction=1
     -Djenkins.install.runSetupWizard=false
     -Djava.awt.headless=true


### PR DESCRIPTION
The jenkins/jenkins:lts image now uses JDK 11 by default, see this [blog](https://www.jenkins.io/blog/2021/08/17/docker-images-use-jdk-11-by-default/) post.