### PR TITLE
NXBT-3588: Fix Nexus and other broken deployments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,54 +77,50 @@ pipeline {
       steps {
         setGitHubBuildStatus('update-ci', 'Update Platform CI', 'PENDING')
         container('base') {
-          // https://jira.nuxeo.com/browse/NXBT-3548
-          // disable `jx upgrade platform` stuck because of exposecontroller image failed to be pulled,
-          // waiting to completely stop relying on `jx`
-          //
-          // echo """
-          // ----------------------------------------------
-          // Upgrade Jenkins X Platform: Nexus, ChartMuseum
-          // Namespace: ${NAMESPACE}
-          // ----------------------------------------------"""
-          // dir('jenkins-x-platform') {
-          //   echo "With jx we're stuck with Helm 2"
-          //   echo 'Helm 2 version:'
-          //   sh 'helm version'
+          echo """
+          ----------------------------------------------
+          Upgrade Jenkins X Platform: Nexus, ChartMuseum
+          Namespace: ${NAMESPACE}
+          ----------------------------------------------"""
+          dir('jenkins-x-platform') {
+            echo "With jx we're stuck with Helm 2"
+            echo 'Helm 2 version:'
+            sh 'helm version'
 
-          //   echo 'initialize Helm without installing Tiller'
-          //   sh 'helm init --client-only --stable-repo-url=https://charts.helm.sh/stable'
+            echo 'initialize Helm without installing Tiller'
+            sh 'helm init --client-only --stable-repo-url=https://charts.helm.sh/stable'
 
-          //   echo 'add local chart repository'
-          //   sh 'helm repo add jenkins-x https://jenkins-x-charts.github.io/v2/'
+            echo 'add local chart repository'
+            sh 'helm repo add jenkins-x https://jenkins-x-charts.github.io/v2/'
 
-          //   echo 'create or update Docker Ingress/Service'
-          //   sh '''
-          //     envsubst < templates/docker-service.yaml > templates/docker-service.yaml~gen
-          //     kubectl apply -f templates/docker-service.yaml~gen
-          //   '''
+            echo 'create or update Docker Ingress/Service'
+            sh '''
+              envsubst < templates/docker-service.yaml > templates/docker-service.yaml~gen
+              kubectl apply -f templates/docker-service.yaml~gen
+            '''
 
-          //   echo 'jx version:'
-          //   sh 'jx version --no-verify=true --no-version-check=true'
+            echo 'jx version:'
+            sh 'jx version --no-verify=true --no-version-check=true'
 
-          //   echo 'upgrade Jenkins X Platform'
-          //   withCredentials([string(credentialsId: 'jenkins-docker-cfg', variable: 'DOCKER_REGISTRY_CONFIG')]) {
-          //     sh 'envsubst < values.yaml > myvalues.yaml'
-          //   }
-          //   sh """
-          //     jx upgrade platform --namespace=${NAMESPACE} \
-          //       --version ${JX_VERSION} \
-          //       --local-cloud-environment \
-          //       --always-upgrade \
-          //       --cleanup-temp-files=true \
-          //       --batch-mode
-          //   """
+            echo 'upgrade Jenkins X Platform'
+            withCredentials([string(credentialsId: 'jenkins-docker-cfg', variable: 'DOCKER_REGISTRY_CONFIG')]) {
+              sh 'envsubst < values.yaml > myvalues.yaml'
+            }
+            sh """
+              jx upgrade platform --namespace=${NAMESPACE} \
+                --version ${JX_VERSION} \
+                --local-cloud-environment \
+                --always-upgrade \
+                --cleanup-temp-files=true \
+                --batch-mode
+            """
 
-          //   echo 'disable unwanted gc cron jobs'
-          //   sh """
-          //     kubectl --namespace=${NAMESPACE} delete cronjob jenkins-x-gcactivities
-          //     kubectl --namespace=${NAMESPACE} delete cronjob jenkins-x-gcpods
-          //   """
-          // }
+            echo 'disable unwanted gc cron jobs'
+            sh """
+              kubectl --namespace=${NAMESPACE} delete cronjob jenkins-x-gcactivities
+              kubectl --namespace=${NAMESPACE} delete cronjob jenkins-x-gcpods
+            """
+          }
 
           echo """
           ----------------------------------------------------------------------

--- a/charts/jenkins/values.yaml.gotmpl
+++ b/charts/jenkins/values.yaml.gotmpl
@@ -6,7 +6,7 @@ controller:
   # Use a fixed version, instead of the `lts` moving tag, to avoid automatic upgrades when the pod is restarted.
   # This happens typically when the Kubernetes node pool is upgraded by GCP and is not wanted since there can be some
   # breaking changes in the Jenkins LTS image.
-  tag: 2.303.3
+  tag: 2.319.2
   resources:
     requests:
       cpu: "200m"

--- a/jenkins-x-platform/values.yaml
+++ b/jenkins-x-platform/values.yaml
@@ -1,5 +1,7 @@
 # used to generate an ingress for nexus and chartmuseum
 expose:
+  Image: "ghcr.io/jenkins-x/exposecontroller"
+  ImageTag: "2.3.118"
   config:
     domain: dev.nuxeo.com
     exposer: Ingress
@@ -15,8 +17,8 @@ docker-registry:
   enabled: false
 nexus:
   image:
-    repository: gcr.io/jenkinsxio/nexus
-    tag: 0.1.36
+    repository: ghcr.io/jenkins-x/nexus
+    tag: 0.1.41
   env:
     # Fix system status warning about available CPUs: "The host system is allocating a maximum of 1 cores to the application. A minimum of 4 is recommended.",
     # by specifying the active processor count.
@@ -25,6 +27,10 @@ nexus:
   persistence:
     size: 310Gi
     storageClass: standard
+controllerrole:
+  image:
+    repository: ghcr.io/jenkins-x/builder-jx
+    tag: 2.1.155-779-patch2
 PipelineSecrets:
   DockerConfig: |-
     $DOCKER_REGISTRY_CONFIG


### PR DESCRIPTION
By reactivating `jx upgrade platform` and pointing to the new Jenkins X v2 image registry.

By the way, upgrade nexus and controllerrole images to the latest tag.
