### PR TITLE
Task NXBT-3753 adjusts resources

### DIFF
--- a/charts/aws-credentials/templates/cronjob.yaml
+++ b/charts/aws-credentials/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: aws-credentials-rotator
@@ -16,7 +16,6 @@ spec:
           - name: aws-credentials-rotator
             image: {{ .Values.cronjob.image }}
           restartPolicy: Never
-          serviceAccount: aws-credentials-updater
           serviceAccountName: aws-credentials-updater
           nodeSelector:
             team: platform

--- a/charts/jenkins/pod-templates/base.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/base.yaml.gotmpl
@@ -15,8 +15,8 @@
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "1"
     resourceLimitMemory: "1Gi"
-    resourceRequestCpu: "200m"
-    resourceRequestMemory: "256Mi"
+    resourceRequestCpu: "250m"
+    resourceRequestMemory: "1Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   envVars:

--- a/charts/jenkins/pod-templates/nodejs.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nodejs.yaml.gotmpl
@@ -14,9 +14,9 @@
     name: "nodejs"
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "2"
-    resourceLimitMemory: "2048Mi"
-    resourceRequestCpu: "400m"
-    resourceRequestMemory: "512Mi"
+    resourceLimitMemory: "2Gi"
+    resourceRequestCpu: "500m"
+    resourceRequestMemory: "2Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   envVars:

--- a/charts/jenkins/pod-templates/nuxeo-benchmark-lts-2021.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-benchmark-lts-2021.yaml.gotmpl
@@ -14,9 +14,9 @@
     name: "maven"
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "2"
-    resourceLimitMemory: "2Gi"
+    resourceLimitMemory: "4Gi"
     resourceRequestCpu: "2"
-    resourceRequestMemory: "2Gi"
+    resourceRequestMemory: "4Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   - args: ""

--- a/charts/jenkins/pod-templates/nuxeo-benchmark-lts-2023.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-benchmark-lts-2023.yaml.gotmpl
@@ -14,9 +14,9 @@
     name: "maven"
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "2"
-    resourceLimitMemory: "2Gi"
+    resourceLimitMemory: "4Gi"
     resourceRequestCpu: "2"
-    resourceRequestMemory: "2Gi"
+    resourceRequestMemory: "4Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   - args: ""

--- a/charts/jenkins/pod-templates/nuxeo-js-client.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-js-client.yaml.gotmpl
@@ -16,7 +16,7 @@
     resourceLimitCpu: "2"
     resourceLimitMemory: "2Gi"
     resourceRequestCpu: "1"
-    resourceRequestMemory: "1Gi"
+    resourceRequestMemory: "2Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   - args: ""
@@ -28,7 +28,7 @@
     resourceLimitCpu: "2"
     resourceLimitMemory: "2Gi"
     resourceRequestCpu: "1"
-    resourceRequestMemory: "1Gi"
+    resourceRequestMemory: "2Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   envVars:

--- a/charts/jenkins/pod-templates/nuxeo-jsf-lts-2021.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-jsf-lts-2021.yaml.gotmpl
@@ -16,7 +16,7 @@
     resourceLimitCpu: "3"
     resourceLimitMemory: "6Gi"
     resourceRequestCpu: "1.5"
-    resourceRequestMemory: "4Gi"
+    resourceRequestMemory: "6Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   envVars:

--- a/charts/jenkins/pod-templates/nuxeo-jsf-lts-2023.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-jsf-lts-2023.yaml.gotmpl
@@ -16,7 +16,7 @@
     resourceLimitCpu: "3"
     resourceLimitMemory: "6Gi"
     resourceRequestCpu: "1.5"
-    resourceRequestMemory: "4Gi"
+    resourceRequestMemory: "6Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   envVars:

--- a/charts/jenkins/pod-templates/nuxeo-openshift.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-openshift.yaml.gotmpl
@@ -15,8 +15,8 @@
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "1"
     resourceLimitMemory: "1Gi"
-    resourceRequestCpu: "200m"
-    resourceRequestMemory: "256Mi"
+    resourceRequestCpu: "250m"
+    resourceRequestMemory: "1Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   envVars:

--- a/charts/jenkins/pod-templates/nuxeo-package-10.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-package-10.yaml.gotmpl
@@ -13,10 +13,10 @@
     alwaysPullImage: true
     name: "maven"
     privileged: {{ .Values.podTemplates.privileged }}
-    resourceLimitCpu: "3"
-    resourceLimitMemory: "3Gi"
-    resourceRequestCpu: "1.5"
-    resourceRequestMemory: "2Gi"
+    resourceLimitCpu: "4"
+    resourceLimitMemory: "8Gi"
+    resourceRequestCpu: "2"
+    resourceRequestMemory: "8Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   envVars:

--- a/charts/jenkins/pod-templates/nuxeo-package-lts-2021.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-package-lts-2021.yaml.gotmpl
@@ -13,10 +13,10 @@
     alwaysPullImage: true
     name: "maven"
     privileged: {{ .Values.podTemplates.privileged }}
-    resourceLimitCpu: "3"
-    resourceLimitMemory: "3Gi"
-    resourceRequestCpu: "1.5"
-    resourceRequestMemory: "2Gi"
+    resourceLimitCpu: "4"
+    resourceLimitMemory: "8Gi"
+    resourceRequestCpu: "2"
+    resourceRequestMemory: "8Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   - args: ""
@@ -26,9 +26,9 @@
     name: "playwright"
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "2"
-    resourceLimitMemory: "1Gi"
+    resourceLimitMemory: "4Gi"
     resourceRequestCpu: "1"
-    resourceRequestMemory: "512Mi"
+    resourceRequestMemory: "4Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   envVars:

--- a/charts/jenkins/pod-templates/nuxeo-package-lts-2023.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-package-lts-2023.yaml.gotmpl
@@ -13,10 +13,10 @@
     alwaysPullImage: true
     name: "maven"
     privileged: {{ .Values.podTemplates.privileged }}
-    resourceLimitCpu: "3"
-    resourceLimitMemory: "3Gi"
-    resourceRequestCpu: "1.5"
-    resourceRequestMemory: "2Gi"
+    resourceLimitCpu: "4"
+    resourceLimitMemory: "8Gi"
+    resourceRequestCpu: "2"
+    resourceRequestMemory: "8Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   - args: ""
@@ -26,9 +26,9 @@
     name: "playwright"
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "2"
-    resourceLimitMemory: "1Gi"
+    resourceLimitMemory: "4Gi"
     resourceRequestCpu: "1"
-    resourceRequestMemory: "512Mi"
+    resourceRequestMemory: "4Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   envVars:

--- a/charts/jenkins/pod-templates/nuxeo-platform-10.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-platform-10.yaml.gotmpl
@@ -16,7 +16,7 @@
     resourceLimitCpu: "2"
     resourceLimitMemory: "4Gi"
     resourceRequestCpu: "1"
-    resourceRequestMemory: "2Gi"
+    resourceRequestMemory: "4Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   envVars:

--- a/charts/jenkins/pod-templates/nuxeo-platform-lts-2021.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-platform-lts-2021.yaml.gotmpl
@@ -26,9 +26,9 @@
     name: "maven-mongodb"
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "4"
-    resourceLimitMemory: "4Gi"
+    resourceLimitMemory: "8Gi"
     resourceRequestCpu: "4"
-    resourceRequestMemory: "4Gi"
+    resourceRequestMemory: "8Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   - args: ""
@@ -38,9 +38,9 @@
     name: "maven-postgresql"
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "4"
-    resourceLimitMemory: "4Gi"
+    resourceLimitMemory: "8Gi"
     resourceRequestCpu: "4"
-    resourceRequestMemory: "4Gi"
+    resourceRequestMemory: "8Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   envVars:

--- a/charts/jenkins/pod-templates/nuxeo-platform-lts-2023.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-platform-lts-2023.yaml.gotmpl
@@ -26,9 +26,9 @@
     name: "maven-mongodb"
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "4"
-    resourceLimitMemory: "4Gi"
+    resourceLimitMemory: "8Gi"
     resourceRequestCpu: "4"
-    resourceRequestMemory: "4Gi"
+    resourceRequestMemory: "8Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   - args: ""
@@ -38,9 +38,9 @@
     name: "maven-postgresql"
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "4"
-    resourceLimitMemory: "4Gi"
+    resourceLimitMemory: "8Gi"
     resourceRequestCpu: "4"
-    resourceRequestMemory: "4Gi"
+    resourceRequestMemory: "8Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   envVars:

--- a/charts/jenkins/pod-templates/nuxeo-web-ui-ftests.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-web-ui-ftests.yaml.gotmpl
@@ -26,9 +26,9 @@
     name: "playwright"
     privileged: {{ .Values.podTemplates.privileged }}
     resourceLimitCpu: "1"
-    resourceLimitMemory: "1Gi"
+    resourceLimitMemory: "2Gi"
     resourceRequestCpu: "500m"
-    resourceRequestMemory: "250Mi"
+    resourceRequestMemory: "2Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
   envVars:

--- a/environments/common.yaml
+++ b/environments/common.yaml
@@ -56,11 +56,7 @@ podTemplates:
   - envVar:
       key: "JAVA_TOOL_OPTIONS"
       value: "-Dsun.zip.disableMemoryMapping=true
-        -XX:+UseParallelGC
-        -XX:MinHeapFreeRatio=5
-        -XX:MaxHeapFreeRatio=10
-        -XX:GCTimeRatio=4
-        -XX:AdaptiveSizePolicyWeight=90"
+        -XX:+UseG1GC"
   mavenEnvVars:
   - envVar:
       key: "MAVEN_OPTS"


### PR DESCRIPTION
The general rule about resources I tried to apply is to have memory requests == memory limits == 4 * cpu requests, as we have 4 times more memory on the Kubernetes nodes than CPU.

For nuxeo-lts pod templates, I followed what we applied in the past, which is more or less memory requests == memory limits == 2 * cpu requests == 2 * cpu limits.