### PR TITLE
NXBT-3783: Upgrade Docker Engine to >= 25.0.2 and Buildkit to >= 0.12.5

### DIFF
--- a/charts/buildkit/values.yaml.gotmpl
+++ b/charts/buildkit/values.yaml.gotmpl
@@ -10,7 +10,7 @@ buildkitd:
   image:
     repository: moby/buildkit
     tag: buildx-stable-1
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   readinessProbe:
     command:
     - buildctl

--- a/environments/common.yaml
+++ b/environments/common.yaml
@@ -16,6 +16,7 @@ podTemplates:
   - args: ""
     command: ""
     image: docker:dind
+    alwaysPullImage: true
     name: dind-daemon
     privileged: true
     resourceRequestCpu: "20m"


### PR DESCRIPTION
Always pull image to make sure the moving tag is up-to-date for:
- The `docker:dind` image, included in the pod templates.
- The `moby/buildkit:buildx-stable-1` image, included in the Buildkit builder pods.
