### PR TITLE
fix-NXP-32215-Gatling-Feeder-randomly-failing

### DIFF
--- a/charts/jenkins-extra/templates/config-redis.yaml
+++ b/charts/jenkins-extra/templates/config-redis.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-conf
+  labels:
+    app.kubernetes.io/name: jenkins
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  redis.conf: | {{ .Values.configMap.redis.config | nindent 4 }}

--- a/charts/jenkins-extra/values.yaml.gotmpl
+++ b/charts/jenkins-extra/values.yaml.gotmpl
@@ -52,6 +52,9 @@ configMap:
         "Name": "skaffold-builder-multiplatform",
         "Global":false
       }
+  redis:
+    config: |-
+      no-appendfsync-on-rewrite yes
 secret:
   mavenSettings:
     labels: {}

--- a/environments/common.yaml
+++ b/environments/common.yaml
@@ -96,6 +96,9 @@ podTemplates:
       configMapName: "docker-buildx"
       mountPath: "/home/jenkins/.buildx/current"
       subPath: "current"
+  - configMapVolume:
+      configMapName: "redis-conf"
+      mountPath: "/opt/bitnami/redis/mounted-etc"
   - secretVolume:
       mountPath: "/home/jenkins/.docker"
       secretName: "jenkins-docker-cfg"


### PR DESCRIPTION
## TL;DR
switched `no-appendfsync-on-rewrite` to `yes`.

---
### About `no-appendfsync-on-rewrite`
From [the Redis config file example](https://raw.githubusercontent.com/redis/redis/6.2/redis.conf)
```
# When the AOF fsync policy is set to always or everysec, and a background
# saving process (a background save or AOF log background rewriting) is
# performing a lot of I/O against the disk, in some Linux configurations
# Redis may block too long on the fsync() call. Note that there is no fix for
# this currently, as even performing fsync in a different thread will block
# our synchronous write(2) call.
#
# In order to mitigate this problem it's possible to use the following option
# that will prevent fsync() from being called in the main process while a
# BGSAVE or BGREWRITEAOF is in progress.
#
# This means that while another child is saving, the durability of Redis is
# the same as "appendfsync none". In practical terms, this means that it is
# possible to lose up to 30 seconds of log in the worst scenario (with the
# default Linux settings).
#
# If you have latency problems turn this to "yes". Otherwise leave it as
# "no" that is the safest pick from the point of view of durability.

no-appendfsync-on-rewrite no
```
### Testing
[Tested in staging](https://jenkins.platform-staging.dev.nuxeo.com/blue/organizations/jenkins/nuxeo%2Flts%2Fnuxeo-benchmark/detail/nuxeo-benchmark/12/pipeline). I have opened a shell in the redis container to assert the following:
- verified the presence of the config file.
- used `redis-cli` to check the configuration was taken into account
- collected the following logs with no more AOF:
```
1:M 06 Mar 2024 01:26:57.139 # Server initialized
1:M 06 Mar 2024 01:26:57.140 * Ready to accept connections
1:M 06 Mar 2024 01:28:15.869 * 10000 changes in 60 seconds. Saving...
1:M 06 Mar 2024 01:28:15.869 * Background saving started by pid 18
18:C 06 Mar 2024 01:28:15.906 * DB saved on disk
18:C 06 Mar 2024 01:28:15.906 * RDB: 0 MB of memory used by copy-on-write
1:M 06 Mar 2024 01:28:15.970 * Background saving terminated with success
...
```
old logs are like:
```
1:M 05 Mar 2024 12:40:29.946 # Server initialized
1:M 05 Mar 2024 12:40:29.947 * Ready to accept connections
1:M 05 Mar 2024 13:08:07.568 * Starting automatic rewriting of AOF on 6712387900% growth
1:M 05 Mar 2024 13:08:07.572 * Background append only file rewriting started by pid 39
1:M 05 Mar 2024 13:08:09.845 * AOF rewrite child asks to stop sending diffs.
39:C 05 Mar 2024 13:08:09.845 * Parent agreed to stop sending diffs. Finalizing AOF...
39:C 05 Mar 2024 13:08:09.845 * Concatenating 0.96 MB of AOF diff received from parent.
39:C 05 Mar 2024 13:08:09.853 * SYNC append only file rewrite performed
39:C 05 Mar 2024 13:08:09.856 * AOF rewrite: 7 MB of memory used by copy-on-write
1:M 05 Mar 2024 13:08:09.913 * Background AOF rewrite terminated with success
1:M 05 Mar 2024 13:08:09.913 * Residual parent diff successfully flushed to the rewritten AOF (0.04 MB)
1:M 05 Mar 2024 13:08:09.914 * Background AOF rewrite finished successfully
...
```

### Automation scripting breaking change
... Just kidding...