### PR TITLE
NXBT-3956: Update nuxeo-js-client pod template to use Node.js 20 and 24

### DIFF
--- a/charts/jenkins/pod-templates/nuxeo-js-client.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-js-client.yaml.gotmpl
@@ -9,7 +9,7 @@
   {{- toYaml .Values.podTemplates.containers | nindent 2 -}}
   - args: ""
     command: ""
-    image: "{{ .Values.docker.registry }}/nuxeo/builder-nodejs16:latest"
+    image: "{{ .Values.docker.registry }}/nuxeo/builder-nodejs24:latest"
     alwaysPullImage: true
     name: "nodejs-active"
     privileged: {{ .Values.podTemplates.privileged }}
@@ -21,7 +21,7 @@
     workingDir: {{ .Values.podTemplates.workingDir }}
   - args: ""
     command: ""
-    image: "{{ .Values.docker.registry }}/nuxeo/builder-nodejs14:latest"
+    image: "{{ .Values.docker.registry }}/nuxeo/builder-nodejs20:latest"
     alwaysPullImage: true
     name: "nodejs-maintenance"
     privileged: {{ .Values.podTemplates.privileged }}


### PR DESCRIPTION
## Summary

- Update the `nuxeo-js-client` pod template to reference the new Node.js builder images:
  - `nodejs-active`: `builder-nodejs16` -> `builder-nodejs24`
  - `nodejs-maintenance`: `builder-nodejs14` -> `builder-nodejs20`

## Context

[NXBT-3956](https://hyland.atlassian.net/browse/NXBT-3956) - Run Nuxeo JS Client Tests on Node.js 20 and 24

**Dependency:** This PR depends on the companion [platform-builders PR](https://github.com/nuxeo/platform-builders) being merged and built first, so that `builder-nodejs20` and `builder-nodejs24` images exist in the Docker registry.