### PR TITLE
feat: add mcp-server Jenkins plugin

### DIFF
--- a/charts/jenkins/values.yaml.gotmpl
+++ b/charts/jenkins/values.yaml.gotmpl
@@ -61,6 +61,7 @@ controller:
   - jira-steps
   - lockable-resources
   - matrix-auth
+  - mcp-server
   - parameterized-scheduler
   - pipeline-github
   - pipeline-utility-steps


### PR DESCRIPTION
## Summary

Add the [MCP Server](https://plugins.jenkins.io/mcp-server/) plugin to the Jenkins deployment.

This plugin implements the server-side of the Model Context Protocol, enabling Jenkins to act as an MCP server and exposing Jenkins functionalities as MCP tools and resources for LLM-powered applications and IDEs (e.g. GitHub Copilot, Cursor...).

No additional configuration is required — the plugin automatically sets up the necessary endpoints upon installation.

## Endpoints available after installation

- `<jenkins-url>/mcp-health` — health check (no auth required)
- `<jenkins-url>/mcp-server/metrics` — connection metrics (auth required)