### PR TITLE
NXBT-3959: increase MCP server SSE timeout

### DIFF
--- a/charts/jenkins/values.yaml.gotmpl
+++ b/charts/jenkins/values.yaml.gotmpl
@@ -18,6 +18,11 @@ controller:
       memory: "12Gi"
   # Secrets made available in `JCasC` through `${SECRET_KEY_NAME}`, requires an existing `jenkins-casc` secret.
   existingSecret: jenkins-casc
+  # Raise Jetty's keep-alive window to 10 minutes (600 000 ms).
+  # The MCP Server plugin sends keep-alive pings every 30 s; Jetty's default of 30 s creates a
+  # race condition that terminates SSE connections just before the next ping arrives.
+  # See https://plugins.jenkins.io/mcp-server/#plugin-content-production-deployment
+  jenkinsOpts: "--httpKeepAliveTimeout=600000"
   # Among others, enable permissions for the extended-read-permission plugin.
   javaOpts: >
     -XX:InitialRAMPercentage=50
@@ -116,6 +121,19 @@ controller:
   ingress:
     enabled: true
     hostName: jenkins.{{ .Values.namespace }}.dev.nuxeo.com
+    # Raise proxy timeouts to 600 s for the whole Jenkins ingress so that long-lived MCP SSE
+    # connections are not cut by Nginx before Jetty's keep-alive window (also 600 s).
+    # Buffering is disabled for MCP paths via the configuration snippet below.
+    # See https://plugins.jenkins.io/mcp-server/#plugin-content-production-deployment
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        location ~ ^/(mcp-server|mcp-health)/ {
+          proxy_request_buffering off;
+          proxy_buffering off;
+          proxy_set_header Connection "";
+        }
     tls:
     - hosts:
       - jenkins.{{ .Values.namespace }}.dev.nuxeo.com


### PR DESCRIPTION
## Problem

Jenkins logs show repeated MCP SSE message handling timeouts:

```
WARNING  Endpoint#handleSseMessageWithTimeout: MCP SSE message handling timed out after 30s
SEVERE   HttpServletSseServerTransportProvider#doPost: Error processing message: java.lang.InterruptedException
```

**Root cause:** Jenkins/Jetty defaults `httpKeepAliveTimeout` to 30 s. The MCP Server plugin sends keep-alive pings every 30 s. This creates a race condition where Jetty closes the HTTP connection just before the next ping arrives.

## Changes

Two mitigations from the [plugin documentation](https://plugins.jenkins.io/mcp-server/#plugin-content-production-deployment) are applied in `charts/jenkins/values.yaml.gotmpl`:

### 1. Winstone `--httpKeepAliveTimeout`
Raises Jetty's keep-alive window from 30 s to 10 minutes via `controller.jenkinsOpts`, eliminating the race condition.

### 2. Nginx proxy timeouts & buffering
- `proxy-read-timeout` and `proxy-send-timeout` raised to 600 s on the Jenkins ingress
- `proxy_buffering` and `proxy_request_buffering` disabled for `/mcp-server/` and `/mcp-health/` paths via a configuration snippet

## Notes
- Staging uses `ingressNginx.enabled: false` so the ingress annotations have no effect there (harmless)
- The MCP plugin keep-alive interval (default 30 s) does not need to change once Jetty's timeout is extended

Ref: NXBT-3959