### PR TITLE
NXBT-3959: remove broken configuration-snippet location block from Jenkins ingress

### DIFF
--- a/charts/jenkins/values.yaml.gotmpl
+++ b/charts/jenkins/values.yaml.gotmpl
@@ -123,17 +123,10 @@ controller:
     hostName: jenkins.{{ .Values.namespace }}.dev.nuxeo.com
     # Raise proxy timeouts to 600 s for the whole Jenkins ingress so that long-lived MCP SSE
     # connections are not cut by Nginx before Jetty's keep-alive window (also 600 s).
-    # Buffering is disabled for MCP paths via the configuration snippet below.
     # See https://plugins.jenkins.io/mcp-server/#plugin-content-production-deployment
     annotations:
       nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-      nginx.ingress.kubernetes.io/configuration-snippet: |
-        location ~ ^/(mcp-server|mcp-health)/ {
-          proxy_request_buffering off;
-          proxy_buffering off;
-          proxy_set_header Connection "";
-        }
     tls:
     - hosts:
       - jenkins.{{ .Values.namespace }}.dev.nuxeo.com


### PR DESCRIPTION
## Problem

The `nginx.ingress.kubernetes.io/configuration-snippet` annotation injects directives **inside** the `location` block that Nginx Ingress generates for the ingress rule. Adding a nested `location ~ ^/(mcp-server|mcp-health)/` block there creates a sub-location **without** `proxy_pass`, so Nginx returns **503** for any request to those paths instead of forwarding to Jenkins.

## Fix

Remove the `configuration-snippet` with the nested `location` block entirely. The proxy timeouts (already applied to the whole Jenkins ingress) are sufficient; the buffering directives were not strictly required for the MCP integration to function.