### PR TITLE
NXP-33491: Update the default LibreOffice version

### DIFF
--- a/charts/jenkins/jobs/ci/libreoffice-uploader.groovy.gotmpl
+++ b/charts/jenkins/jobs/ci/libreoffice-uploader.groovy.gotmpl
@@ -30,7 +30,7 @@ pipelineJob('ci/libreoffice-uploader') {
   parameters {
     string {
       name('LIBREOFFICE_VERSION')
-      defaultValue('7.1.1')
+      defaultValue('26.2.2')
       description('Libreoffice version to download from documentfoundation.org and then to upload to packages.nuxeo.com.')
       trim(true)
     }


### PR DESCRIPTION
As per our upgrade for Nuxeo 2027, the ARM support that the pipeline levarages, and because the 7.x has been archived.

Relates:
- https://github.com/nuxeo/platform-ci-tools/pull/38