### PR TITLE
NXENG-338: Add maven-documentdb container to nuxeo-platform-lts-2025 pod template

### DIFF
--- a/charts/jenkins/pod-templates/nuxeo-platform-lts-2025.yaml.gotmpl
+++ b/charts/jenkins/pod-templates/nuxeo-platform-lts-2025.yaml.gotmpl
@@ -43,6 +43,18 @@
     resourceRequestMemory: "8Gi"
     ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
     workingDir: {{ .Values.podTemplates.workingDir }}
+  - args: ""
+    command: ""
+    image: "{{ .Values.docker.registry }}/nuxeo/builder-java21:latest"
+    alwaysPullImage: true
+    name: "maven-documentdb"
+    privileged: {{ .Values.podTemplates.privileged }}
+    resourceLimitCpu: "4"
+    resourceLimitMemory: "8Gi"
+    resourceRequestCpu: "4"
+    resourceRequestMemory: "8Gi"
+    ttyEnabled: {{ .Values.podTemplates.ttyEnabled }}
+    workingDir: {{ .Values.podTemplates.workingDir }}
   envVars:
   {{- toYaml .Values.podTemplates.envVars | nindent 2 -}}
   {{- toYaml .Values.podTemplates.javaEnvVars | nindent 2 -}}


### PR DESCRIPTION
## Summary

Adds a `maven-documentdb` sidecar container to the `nuxeo-platform-lts-2025` Jenkins agent pod template, required by the new DocumentDB unit test stage added in `nuxeo-lts` PR #4499.

## Changes

- **`charts/jenkins/pod-templates/nuxeo-platform-lts-2025.yaml.gotmpl`** — new `maven-documentdb` container block, identical to `maven-mongodb` / `maven-postgresql` (same `builder-java21:latest` image, same resource limits)

## Related

- `nuxeo-lts` draft PR: https://github.com/nuxeo/nuxeo-lts/pull/4499
